### PR TITLE
Move WhatRan to a method on the struct, not a return

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Once all our CLI parameter objects are registered, the main function
 of the library is invoked:
 
 ```
-_, err := cl.ParseAndRun(os.Args[1:], []string{"Check", "Draw"}, cmdline.ShowHelpIfNoArgs)
+err := cl.ParseAndRun(os.Args[1:], []string{"Check", "Draw"}, cmdline.ShowHelpIfNoArgs)
 ```
 
 This parses the command-line arguments, and then runs two execution

--- a/cmd/example.go
+++ b/cmd/example.go
@@ -45,7 +45,7 @@ func main() {
 	cl := cmdline.NewCmdline()
 	cl.AddConfigType("circle", "Circle Shape", circle{})
 	cl.AddConfigType("rectangle", "Rectangle Shape", rectangle{})
-	_, err := cl.ParseAndRun(os.Args[1:], []string{"Check", "Draw"}, cmdline.ShowHelpIfNoArgs)
+	err := cl.ParseAndRun(os.Args[1:], []string{"Check", "Draw"}, cmdline.ShowHelpIfNoArgs)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)

--- a/cmdline_test.go
+++ b/cmdline_test.go
@@ -30,7 +30,7 @@ func TestCmdlinePhases(t *testing.T) {
 	cl := NewCmdline()
 	cl.AddConfigType("PhaseTest", "Phase Test", testPhasesCfg{})
 	testResults = make([]string, 0)
-	_, err := cl.ParseAndRun([]string{"--PhaseTest", "ID=test1", "--PhaseTest", "ID=test2"}, []string{"Init", "Prepare", "Run"})
+	err := cl.ParseAndRun([]string{"--PhaseTest", "ID=test1", "--PhaseTest", "ID=test2"}, []string{"Init", "Prepare", "Run"})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Previously, ParseAndRun was a module-level function that returned a string identifying the exclusive object, if any, that was executed.  Now that ParseAndRun is a struct receiver, we can store this value in the struct for interested callers to access, eliminating the need for a million ugly `return "", err` statements.