### PR TITLE
Don't print the phase name when a config type method fails

### DIFF
--- a/cmdline.go
+++ b/cmdline.go
@@ -1011,7 +1011,7 @@ func (cl *Cmdline) ParseAndRun(args []string, phases []string, options ...func(*
 	for _, phase := range phases {
 		err = runMethod(phase)
 		if err != nil {
-			return fmt.Errorf("error during %s phase: %s", phase, err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
Receptor has tests that depend on the formatting of this error message.