### PR TITLE
Use explicit version to avoid warning about mutable ref

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: master
+    rev: v0.3.5
     hooks:
       - id: go-fmt
       - id: go-lint


### PR DESCRIPTION
This will avoid the warning
```
[WARNING] The 'rev' field of repo 'https://github.com/dnephin/pre-commit-golang' appears to be a mutable reference
```
during the pre-commit CI run.