### PR TITLE
Allow ignoring fields, for private data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ The following tags can be applied to a struct field:
 * `default`: Default value to use if the user does not specify one.
 * `barevalue`: If true, this field can be used as a bare value.    
   (A bare value is like `--item 37` rather than `--item id=37`.)
+* `ignore`: If true, do not use this field for command line processing at all.    
+  (This can be used for private data to be passed between phases, etc.)
 
 ## Data types
 

--- a/cmdline.go
+++ b/cmdline.go
@@ -132,6 +132,10 @@ func printableTypeName(typ reflect.Type) string {
 func recursiveEnumerateFields(typ reflect.Type, results chan<- reflect.StructField) {
 	for i := 0; i < typ.NumField(); i++ {
 		ctf := typ.Field(i)
+		ignore, err := betterParseBool(ctf.Tag.Get("ignore"))
+		if err == nil && ignore {
+			continue
+		}
 		if ctf.Type.Kind() == reflect.Struct {
 			recursiveEnumerateFields(ctf.Type, results)
 		} else {


### PR DESCRIPTION
Add an `ignore` flag to fields in the struct.  Fields marked as `ignore` will not be used in command line processing, but can be accessed by the struct's functions.  Ignored fields can thus be used for maintaining state data or otherwise passing information between phases.