### PR TITLE
App registry for libraries

### DIFF
--- a/cmdline_test.go
+++ b/cmdline_test.go
@@ -303,3 +303,26 @@ func TestYAML(t *testing.T) {
 		t.Error("Actual results did not match expected")
 	}
 }
+
+func TestAppRegistry(t *testing.T) {
+	RegisterConfigTypeForApp("app1", "test1", "", testCfg1{})
+	RegisterConfigTypeForApp("app1", "test2", "", testCfg2{})
+	RegisterConfigTypeForApp("app2", "test3", "", testCfg3{})
+	RegisterConfigTypeForApp("app4", "test4", "", testCfg4{})
+	cl := NewCmdline()
+	cl.AddRegisteredConfigTypes("app1")
+	testResults = make([]string, 0)
+	err := cl.ParseAndRun([]string{"--test1", "ID=hello", "--test2", "Value=goodbye"}, []string{"Run"})
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(testResults, []string{
+		"testCfg1 Run hello",
+	}) {
+		t.Error("Actual results did not match expected")
+	}
+	err = cl.ParseAndRun([]string{"--test3", "ID=hello"}, []string{"Run"})
+	if err == nil {
+		t.Error("test3 should not have been registered")
+	}
+}


### PR DESCRIPTION
One of the intended features of cmdline is to be able to get command line functionality just by importing a module that defines it.  However, some modules serve a dual purpose: they are cmdline app components, but also general-use libraries.  This presents an issue of a library unexpectedly adding cmdline options to an app that imports it.  See https://github.com/ansible/receptor/issues/334.

This PR removes the GlobalInstance variable, and replaces it with a global registry.  Libraries can add named cmdline objects to the registry, but they are not used unless the main application explicitly adds them.

It is legal to call `AddRegisteredConfigTypes` with an unknown `appName` value.  In this case, nothing is added.  This preserves the ability to add or remove functionality, including its command line, by importing or not importing modules.