### PR TITLE
Fix two panic bugs

### DIFF
--- a/cmdline.go
+++ b/cmdline.go
@@ -1042,9 +1042,15 @@ func (cl *Cmdline) ParseAndRun(args []string, phases []string, options ...func(*
 			m := cfgObj.obj.MethodByName(methodName)
 			if m.IsValid() {
 				result := m.Call(make([]reflect.Value, 0))
-				errIf := result[0].Interface()
-				if errIf != nil {
-					return fmt.Errorf("%s", errIf)
+				if len(result) > 0 {
+					errIf := result[0].Interface()
+					if errIf != nil {
+						err, ok := errIf.(error)
+						if ok {
+							return err
+						}
+						return fmt.Errorf("%s", errIf)
+					}
 				}
 			}
 		}

--- a/cmdline.go
+++ b/cmdline.go
@@ -408,6 +408,16 @@ func setValue(field *reflect.Value, value interface{}) error {
 	fieldType := field.Type()
 	fieldKind := fieldType.Kind()
 	valueType := reflect.TypeOf(value)
+
+	// Handle the case where the value to be assigned is nil
+	if valueType == nil {
+		if fieldKind == reflect.Map || fieldKind == reflect.Slice {
+			field.Set(reflect.Zero(fieldType))
+			return nil
+		}
+		return fmt.Errorf("value cannot be nil")
+	}
+
 	valueKind := valueType.Kind()
 
 	// If the destination is a string, try some string conversions


### PR DESCRIPTION
This fixes two cases where cmdline panics:

* When a phase function is declared with an incorrect signature, and returns no value instead of returning an error value
* When a nil value is assigned to a slice or map, as happens with an empty list in a YAML config file